### PR TITLE
HitBulletColor instead of HitBulletSmall will make the hitEffect have the defined hitColor

### DIFF
--- a/src/omaloon/content/blocks/OlDefenceBlocks.java
+++ b/src/omaloon/content/blocks/OlDefenceBlocks.java
@@ -59,7 +59,7 @@ public class OlDefenceBlocks {
                         lifetime = 25f;
                         ammoMultiplier = 3;
 
-                        despawnEffect = Fx.hitBulletSmall;
+                        despawnEffect = Fx.hitBulletColor;
                         hitEffect = Fx.none;
                         hitColor = OlItems.cobalt.color;
 


### PR DESCRIPTION
HitBulletColor instead of HitBulletSmall will make the hitEffect have the defined hitColor